### PR TITLE
 FIX #46: Null propagation no longer results SA1101 or SA1126 violations

### DIFF
--- a/Project/Src/Analyzers/ReadabilityRules.ClassMembers.cs
+++ b/Project/Src/Analyzers/ReadabilityRules.ClassMembers.cs
@@ -138,7 +138,7 @@ namespace StyleCop.CSharp
             if (previousToken.CsTokenType == CsTokenType.OperatorSymbol)
             {
                 OperatorSymbol symbol = (OperatorSymbol)previousToken;
-                if (symbol.SymbolType == OperatorType.MemberAccess || symbol.SymbolType == OperatorType.Pointer || symbol.SymbolType == OperatorType.QualifiedAlias)
+                if (symbol.SymbolType == OperatorType.MemberAccess || symbol.SymbolType == OperatorType.Pointer || symbol.SymbolType == OperatorType.QualifiedAlias || symbol.SymbolType == OperatorType.NullConditional)
                 {
                     return true;
                 }

--- a/Project/Test/CSharpAnalyzersTest/CSharpAnalyzersTest.csproj
+++ b/Project/Test/CSharpAnalyzersTest/CSharpAnalyzersTest.csproj
@@ -66,6 +66,9 @@
   <ItemGroup>
     <Compile Include="AnalyzerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="TestData\ClassMembers\NullPropogation.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestData\Spacing\StringInterpolation.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Project/Test/CSharpAnalyzersTest/TestData/ClassMembers/NullPropogation.cs
+++ b/Project/Test/CSharpAnalyzersTest/TestData/ClassMembers/NullPropogation.cs
@@ -1,0 +1,41 @@
+﻿namespace CSharpAnalyzersTest.TestData.NullPropogation
+{
+    public class NullPropogationCollaborator
+    {
+        public string Method1()
+        {
+            return string.Empty;
+        }
+    }
+
+    public class Class1
+    {
+        private NullPropogationCollaborator field;
+
+        public string Method2()
+        {
+            return this.field?.Method1(); // Valid because method doesn't exist in this class
+        }
+    }
+
+    public class Class2
+    {
+        private NullPropogationCollaborator field;
+
+        public string Method1()
+        {
+            this.field?.Method1(); // Valid because it isn't refering to this class.
+            this.field?
+                .Method1();
+            this.field?.
+                 Method1();
+            this.field
+                ?.Method1();
+        }
+
+        public string Method2()
+        {
+            this.field?.Method1()?.Trim(); // Valid
+        }
+    }
+}

--- a/Project/Test/CSharpAnalyzersTest/TestData/ClassMembers/TestDescription.xml
+++ b/Project/Test/CSharpAnalyzersTest/TestData/ClassMembers/TestDescription.xml
@@ -256,4 +256,31 @@
       <Violation Section="Root.CSharpAnalyzersTest.TestData.Program.Method" LineNumber="47" Rule="PrefixLocalCallsWithThis" />
     </ExpectedViolations>
   </Test>
+
+  <!-- Tests that the null propagation ?. doesn't result in incorrect violations. -->
+  <Test Name="NullPropogationsDoesNotResultInReadabilityViolations">
+    <TestCodeFile>NullPropogation.cs</TestCodeFile>
+    <Settings>
+      <GlobalSettings>
+        <StringProperty Name="MergeSettingsFiles">NoMerge</StringProperty>
+        <BooleanProperty Name="RulesEnabledByDefault">False</BooleanProperty>
+      </GlobalSettings>
+      <Analyzers>
+        <Analyzer AnalyzerId="StyleCop.CSharp.ReadabilityRules">
+          <Rules>
+            <Rule Name="PrefixLocalCallsWithThis">
+              <RuleSettings>
+                <BooleanProperty Name="Enabled">True</BooleanProperty>
+              </RuleSettings>
+            </Rule>
+            <Rule Name="PrefixCallsCorrectly">
+              <RuleSettings>
+                <BooleanProperty Name="Enabled">True</BooleanProperty>
+              </RuleSettings>
+            </Rule>
+          </Rules>
+        </Analyzer>
+      </Analyzers>
+    </Settings>
+  </Test>
 </StyleCopTestDescription>


### PR DESCRIPTION
The null propagation operator is already being accounted for by the parser, but it's treated as a Null Conditional operator. Thus it wasn't being accounted for as a member accessor. This appears to fix it, along with some tests with it.