### PR TITLE
Add missing string format argument. Fixes #49

### DIFF
--- a/Project/Src/StyleCop/StyleCopThread.cs
+++ b/Project/Src/StyleCop/StyleCopThread.cs
@@ -412,7 +412,7 @@ namespace StyleCop
                                 // Add exception message for help on bugfix.
                                 if (!string.IsNullOrEmpty(ex.Message))
                                 {
-                                    details.AppendLine(string.Format(CultureInfo.CurrentCulture, "Exception message : {0}"));
+                                    details.AppendLine(string.Format(CultureInfo.CurrentCulture, "Exception message : {0}", ex.Message));
                                 }
 
                                 this.data.Core.SignalOutput(MessageImportance.High, details.ToString());


### PR DESCRIPTION
If a StyleCop analyzer throws an exception, the analyzer exception message is replaced by an unhelpful message about `string.Format` having the wrong number of parameters (e.g., see #49).

This fixes the error reporting so that the underlying exception message is shown in the Visual Studio output.
